### PR TITLE
Add Automatic-Module-Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,17 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.powsybl.mathnative</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>${maven.build-helper.version}</version>


### PR DESCRIPTION
The chosen name is com.powsybl.mathnative . Do you have preferences on another name ?

Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bugfix


**What is the current behavior?** *(You can also link to an open issue here)*
Can't use this project as an automatic module:
$ java --module-path  powsybl-math-native-1.0.1.jar --module Foo/Bar
Error occurred during initialization of boot layer
java.lang.module.FindException: Unable to derive module descriptor for powsybl-math-native-1.0.1.jar
Caused by: java.lang.IllegalArgumentException: powsybl.math.native: Invalid module name: 'native' is not a Java identifier

Alternatively, this can be diagnosed with:
$jar --file powsybl-math-native-1.0.1.jar --describe-module
Unable to derive module descriptor for: powsybl-math-native-1.0.1.jar
powsybl.math.native: Invalid module name: 'native' is not a Java identifier


**What is the new behavior (if this is a feature change)?**
works.

For example,
$jar --file powsybl-math-native-1.0.1.jar --describe-module
No module descriptor found. Derived automatic module.

com.powsybl.mathnative automatic
requires java.base mandated




**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
