### PR TITLE
Throw MatrixException instead of RuntimeException

### DIFF
--- a/src/jniwrapper.cpp
+++ b/src/jniwrapper.cpp
@@ -14,8 +14,8 @@ namespace powsybl {
 
 namespace jni {
 
-void throwJavaLangRuntimeException(JNIEnv* env, const char* msg) {
-    jclass clazz = env->FindClass("java/lang/RuntimeException");
+void throwMatrixException(JNIEnv* env, const char* msg) {
+    jclass clazz = env->FindClass("com/powsybl/math/matrix/MatrixException");
     env->ThrowNew(clazz, msg);
 }
 

--- a/src/jniwrapper.hpp
+++ b/src/jniwrapper.hpp
@@ -148,7 +148,7 @@ private:
     mutable jdouble* _ptr;
 };
 
-void throwJavaLangRuntimeException(JNIEnv* env, const char* msg);
+void throwMatrixException(JNIEnv* env, const char* msg);
 
 }  // namespace jni
 

--- a/src/lu.cpp
+++ b/src/lu.cpp
@@ -156,9 +156,9 @@ JNIEXPORT void JNICALL Java_com_powsybl_math_matrix_SparseLUDecomposition_init(J
             throw std::runtime_error("klu_factor error " + context.error());
         }
     } catch (const std::exception& e) {
-        powsybl::jni::throwJavaLangRuntimeException(env, e.what());
+        powsybl::jni::throwMatrixException(env, e.what());
     } catch (...) {
-        powsybl::jni::throwJavaLangRuntimeException(env, "Unknown exception");
+        powsybl::jni::throwMatrixException(env, "Unknown exception");
     }
 }
 
@@ -198,9 +198,9 @@ JNIEXPORT jdouble JNICALL Java_com_powsybl_math_matrix_SparseLUDecomposition_upd
         }
         return context.common.rgrowth;
     } catch (const std::exception& e) {
-        powsybl::jni::throwJavaLangRuntimeException(env, e.what());
+        powsybl::jni::throwMatrixException(env, e.what());
     } catch (...) {
-        powsybl::jni::throwJavaLangRuntimeException(env, "Unknown exception");
+        powsybl::jni::throwMatrixException(env, "Unknown exception");
     }
 }
 
@@ -224,9 +224,9 @@ JNIEXPORT void JNICALL Java_com_powsybl_math_matrix_SparseLUDecomposition_releas
 
         MANAGER->removeContext(id);
     } catch (const std::exception& e) {
-        powsybl::jni::throwJavaLangRuntimeException(env, e.what());
+        powsybl::jni::throwMatrixException(env, e.what());
     } catch (...) {
-        powsybl::jni::throwJavaLangRuntimeException(env, "Unknown exception");
+        powsybl::jni::throwMatrixException(env, "Unknown exception");
     }
 }
 
@@ -252,9 +252,9 @@ JNIEXPORT void JNICALL Java_com_powsybl_math_matrix_SparseLUDecomposition_solve(
             }
         }
     } catch (const std::exception& e) {
-        powsybl::jni::throwJavaLangRuntimeException(env, e.what());
+        powsybl::jni::throwMatrixException(env, e.what());
     } catch (...) {
-        powsybl::jni::throwJavaLangRuntimeException(env, "Unknown exception");
+        powsybl::jni::throwMatrixException(env, "Unknown exception");
     }
 }
 
@@ -283,9 +283,9 @@ JNIEXPORT void JNICALL Java_com_powsybl_math_matrix_SparseLUDecomposition_solve2
             }
         }
     } catch (const std::exception& e) {
-        powsybl::jni::throwJavaLangRuntimeException(env, e.what());
+        powsybl::jni::throwMatrixException(env, e.what());
     } catch (...) {
-        powsybl::jni::throwJavaLangRuntimeException(env, "Unknown exception");
+        powsybl::jni::throwMatrixException(env, "Unknown exception");
     }
 }
 
@@ -299,9 +299,9 @@ JNIEXPORT void JNICALL Java_com_powsybl_math_matrix_SparseMatrix_nativeInit(JNIE
         // lookup caching
         powsybl::jni::ComPowsyblMathMatrixSparseMatrix::init(env);
     } catch (const std::exception& e) {
-        powsybl::jni::throwJavaLangRuntimeException(env, e.what());
+        powsybl::jni::throwMatrixException(env, e.what());
     } catch (...) {
-        powsybl::jni::throwJavaLangRuntimeException(env, "Unknown exception");
+        powsybl::jni::throwMatrixException(env, "Unknown exception");
     }
 }
 
@@ -355,9 +355,9 @@ JNIEXPORT jobject JNICALL Java_com_powsybl_math_matrix_SparseMatrix_times(JNIEnv
 
         return matrix;
     } catch (const std::exception& e) {
-        powsybl::jni::throwJavaLangRuntimeException(env, e.what());
+        powsybl::jni::throwMatrixException(env, e.what());
     } catch (...) {
-        powsybl::jni::throwJavaLangRuntimeException(env, "Unknown exception");
+        powsybl::jni::throwMatrixException(env, "Unknown exception");
     }
     return nullptr;
 }
@@ -393,9 +393,9 @@ JNIEXPORT jobject JNICALL Java_com_powsybl_math_matrix_SparseMatrix_transpose(JN
 
         return matrix;
     } catch (const std::exception& e) {
-        powsybl::jni::throwJavaLangRuntimeException(env, e.what());
+        powsybl::jni::throwMatrixException(env, e.what());
     } catch (...) {
-        powsybl::jni::throwJavaLangRuntimeException(env, "Unknown exception");
+        powsybl::jni::throwMatrixException(env, "Unknown exception");
     }
     return nullptr;
 }
@@ -446,9 +446,9 @@ JNIEXPORT jobject JNICALL Java_com_powsybl_math_matrix_SparseMatrix_add(JNIEnv *
 
         return matrix;
     } catch (const std::exception& e) {
-        powsybl::jni::throwJavaLangRuntimeException(env, e.what());
+        powsybl::jni::throwMatrixException(env, e.what());
     } catch (...) {
-        powsybl::jni::throwJavaLangRuntimeException(env, "Unknown exception");
+        powsybl::jni::throwMatrixException(env, "Unknown exception");
     }
     return nullptr;
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
C++ exception are transferred to Java using a `RuntimeException`. The problem is that it is a too generic exception and there is no way on Java side to filter on matrix calculation related errors.



**What is the new behavior (if this is a feature change)?**
A more dedicated exception is thrown: `MatrixException`


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
