### PR TITLE
Don't use groovy to generate javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>3</version>
+        <version>14</version>
         <relativePath/>
     </parent>
 
@@ -46,13 +46,6 @@
         </developer>
     </developers>
 
-    <properties>
-        <maven.build-helper.version>3.1.0</maven.build-helper.version>
-
-        <groovy.version>2.5.8</groovy.version>
-        <groovydoc.classifier>javadoc</groovydoc.classifier>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -64,16 +57,10 @@
                             <Automatic-Module-Name>com.powsybl.mathnative</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
+                    <excludes>
+                      <exclude>com/powsybl/mathnative/MathNativeJavadocPlaceholder.class</exclude>
+                    </excludes>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.gmavenplus</groupId>
-                <artifactId>gmavenplus-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>${maven.build-helper.version}</version>
             </plugin>
         </plugins>
     </build>
@@ -89,10 +76,9 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>build-helper-maven-plugin</artifactId>
-                        <version>${maven.build-helper.version}</version>
                         <executions>
                             <execution>
-                                <id>add-source</id>
+                                <id>add-cpp-source</id>
                                 <phase>generate-sources</phase>
                                 <goals>
                                     <goal>add-source</goal>

--- a/src/com/powsybl/mathnative/MathNativeJavadocPlaceholder.java
+++ b/src/com/powsybl/mathnative/MathNativeJavadocPlaceholder.java
@@ -1,0 +1,4 @@
+package com.powsybl.mathnative;
+
+/** Placeholder needed by the javadoc tool to generate the javadoc site */
+public class MathNativeJavadocPlaceholder { private MathNativeJavadocPlaceholder() { } }

--- a/src/com/powsybl/mathnative/MathNativeJavadocPlaceholder.java
+++ b/src/com/powsybl/mathnative/MathNativeJavadocPlaceholder.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.mathnative;
 
 /** Placeholder needed by the javadoc tool to generate the javadoc site */

--- a/src/com/powsybl/mathnative/package-info.java
+++ b/src/com/powsybl/mathnative/package-info.java
@@ -1,0 +1,2 @@
+/** Native library binaries for powsybl math operations */
+package com.powsybl.mathnative;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
uses groovy to generate a fake javadoc


**What is the new behavior (if this is a feature change)?**
uses javadoc to generate a javadoc talking about the native lib contents of this jar

**Does this PR introduce a breaking change or deprecate an API?**
NO


**Other information**:
   
    This adds a package-info.class file to the generated jar but it shouldn't be a problem
    This is because maven uses the jar as the input to the javadoc tool and we don't
    want to diverge too much from the maven way (you get problems really fast)
    (In theory, I guess we could generated the javadoc from target/classes instead of target/project.jar)
    
    The generated javadoc has one package with one class because:
    - It doesn't seem to be possible to generate an empty javadoc (no packages).
    - It doesn't seem to be possible to generate an empty package (no classes).
    
    references:
    * https://stackoverflow.com/questions/53706943/how-to-upload-an-artifact-to-maven-central-with-an-empty-javadoc-jar-or-empty-s
     => what we did in 1.0.0 and 1.0.1: totally empty javadoc.jar (valid for maven central upload but ugly)
    * https://stackoverflow.com/questions/59071851/how-to-force-a-javadoc-jar-even-though-there-is-no-public-javadoc
     => still produces a totally empty javadoc.jar (and big scary red errors)
    * https://stackoverflow.com/questions/1138390/javadoc-for-package-info-java-only
     => This plus excluding the class from the jar seems like the best solution for now ?
    
    promising but not yet ready:
    * https://issues.apache.org/jira/browse/MJAVADOC-329
      https://github.com/apache/maven-javadoc-plugin/pull/65
    * https://bugs.openjdk.org/browse/JDK-8193107
      https://hg.openjdk.org/jdk/jdk/rev/111104f1e033
      empty modules are allowed, but does becoming a module work with how the native library are loaded ??
