### PR TITLE
Use FetchContent to consume dependency SuiteSparse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,8 @@ FetchContent_Declare(SuiteSparse
   URL_HASH ${suitesparse_url_has}
   PATCH_COMMAND git apply --ignore-space-change --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/patches/suitesparse.patch)
 
-FetchContent_MakeAvailable(SuiteSparse)
+FetchContent_Populate(SuiteSparse)
+add_subdirectory(${suitesparse_SOURCE_DIR} ${suitesparse_BINARY_DIR} EXCLUDE_FROM_ALL)
 
 set(SOURCES
     src/lu.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,54 +17,24 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(NOPENMP true)
 
-set(THIRD_PARTY_DIR ${CMAKE_CURRENT_BINARY_DIR}/thirdparty)
-
 set(suitesparse_version "7.3.1")
 set(suitesparse_archive "v${suitesparse_version}.tar.gz")
 set(suitesparse_url https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/${suitesparse_archive})
+set(suitesparse_url_hash "MD5=735b8856ce333bf5d8773ba20685c8b8")
 
-# download SuiteSparse archive
-file(DOWNLOAD ${suitesparse_url} ${THIRD_PARTY_DIR}/${suitesparse_archive})
-file(ARCHIVE_EXTRACT INPUT ${THIRD_PARTY_DIR}/${suitesparse_archive} DESTINATION ${THIRD_PARTY_DIR})
-set(suitesparse_source ${THIRD_PARTY_DIR}/SuiteSparse-${suitesparse_version})
+include(FetchContent)
+FetchContent_Declare(SuiteSparse
+  URL ${suitesparse_url}
+  URL_HASH ${suitesparse_url_has}
+  PATCH_COMMAND git apply --ignore-space-change --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/patches/suitesparse.patch)
 
-# patch CMakeLists.txt of SuiteSparse_config module to avoid blas check as it is hard to compile it on windows
-# and that we don't need it for the suitesparse modules we beed (amd, colamd, btf, klu and cxsparse)
-file(READ ${suitesparse_source}/SuiteSparse_config/CMakeLists.txt FILE_CONTENTS)
-string(REPLACE "include ( SuiteSparseBLAS )" "set ( SuiteSparse_BLAS_integer \"int32_t\" )\nset ( BLAS_FOUND true )" FILE_CONTENTS ${FILE_CONTENTS})
-file(WRITE ${suitesparse_source}/SuiteSparse_config/CMakeLists.txt ${FILE_CONTENTS})
-
-list(APPEND CMAKE_MODULE_PATH ${suitesparse_source}/SuiteSparse_config/cmake_modules)
-
-add_subdirectory(${suitesparse_source}/SuiteSparse_config/)
-add_library(SuiteSparse::SuiteSparseConfig ALIAS SuiteSparseConfig)
-add_library(SuiteSparse::SuiteSparseConfig_static ALIAS SuiteSparseConfig_static)
-
-add_subdirectory(${suitesparse_source}/AMD)
-add_library(SuiteSparse::AMD ALIAS AMD)
-add_library(SuiteSparse::AMD_static ALIAS AMD_static)
-
-add_subdirectory(${suitesparse_source}/COLAMD)
-add_library(SuiteSparse::COLAMD ALIAS COLAMD)
-add_library(SuiteSparse::COLAMD_static ALIAS COLAMD_static)
-
-add_subdirectory(${suitesparse_source}/BTF)
-add_library(SuiteSparse::BTF ALIAS BTF)
-add_library(SuiteSparse::BTF_static ALIAS BTF_static)
-
-add_subdirectory(${suitesparse_source}/KLU)
-add_library(SuiteSparse::KLU_static ALIAS KLU_static)
-
-add_subdirectory(${suitesparse_source}/CXSparse)
-add_library(SuiteSparse::CXSparse_static ALIAS CXSparse_static)
+FetchContent_MakeAvailable(SuiteSparse)
 
 set(SOURCES
     src/lu.cpp
     src/jniwrapper.cpp
 )
 add_library(math SHARED ${SOURCES})
-
-add_dependencies(math KLU_static CXSparse_static)
 
 target_include_directories(math
     PUBLIC

--- a/patches/suitesparse.patch
+++ b/patches/suitesparse.patch
@@ -1,0 +1,53 @@
+diff -ruN SuiteSparse-7.3.1/CMakeLists.txt SuiteSparse-7.3.1.patched/CMakeLists.txt
+--- SuiteSparse-7.3.1/CMakeLists.txt	1970-01-01 01:00:00.000000000 +0100
++++ SuiteSparse-7.3.1.patched/CMakeLists.txt	2023-11-20 10:35:03.770174365 +0100
+@@ -0,0 +1,33 @@
++cmake_minimum_required(VERSION 3.20)
++project(SparseSuite)
++
++list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/SuiteSparse_config/cmake_modules")
++
++# avoid blas check as it is hard to compile on windows
++# and that we don't need it for the suitesparse modules we need (amd, colamd, btf, klu and cxsparse)
++set ( SuiteSparse_BLAS_integer "int32_t" )
++set ( BLAS_FOUND true )
++
++add_subdirectory(SuiteSparse_config/)
++add_library(SuiteSparse::SuiteSparseConfig ALIAS SuiteSparseConfig)
++add_library(SuiteSparse::SuiteSparseConfig_static ALIAS SuiteSparseConfig_static)
++
++add_subdirectory(AMD)
++add_library(SuiteSparse::AMD ALIAS AMD)
++add_library(SuiteSparse::AMD_static ALIAS AMD_static)
++
++add_subdirectory(COLAMD)
++add_library(SuiteSparse::COLAMD ALIAS COLAMD)
++add_library(SuiteSparse::COLAMD_static ALIAS COLAMD_static)
++
++add_subdirectory(BTF)
++add_library(SuiteSparse::BTF ALIAS BTF)
++add_library(SuiteSparse::BTF_static ALIAS BTF_static)
++
++add_subdirectory(KLU)
++add_library(SuiteSparse::KLU ALIAS KLU)
++add_library(SuiteSparse::KLU_static ALIAS KLU_static)
++
++add_subdirectory(CXSparse)
++add_library(SuiteSparse::CXSparse ALIAS CXSparse)
++add_library(SuiteSparse::CXSparse_static ALIAS CXSparse_static)
+\ Pas de fin de ligne à la fin du fichier
+diff -ruN SuiteSparse-7.3.1/SuiteSparse_config/CMakeLists.txt SuiteSparse-7.3.1.patched/SuiteSparse_config/CMakeLists.txt
+--- SuiteSparse-7.3.1/SuiteSparse_config/CMakeLists.txt	2023-11-03 23:42:14.000000000 +0100
++++ SuiteSparse-7.3.1.patched/SuiteSparse_config/CMakeLists.txt	2023-11-20 10:47:59.326178237 +0100
+@@ -62,7 +62,10 @@
+     find_package ( OpenMP )
+ endif ( )
+ 
+-include ( SuiteSparseBLAS )
++## patch CMakeLists.txt of SuiteSparse_config module to avoid blas check as it is hard to compile on windows
++## and that we don't need it for the suitesparse modules we need (amd, colamd, btf, klu and cxsparse)
++set ( SuiteSparse_BLAS_integer "int32_t" )
++set ( BLAS_FOUND true )
+ 
+ #-------------------------------------------------------------------------------
+ # configure files


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines

**What kind of change does this PR introduce?**
This is an enhancement for CMake configuration to consume project SuiteSparse using FetchContent and pushing all targets definitions into a patch rather than in the main CMakeLists.txt file.


**What is the new behavior (if this is a feature change)?**
This not a feature change.


**Does this PR introduce a breaking change or deprecate an API?**
No
