### PR TITLE
Update to parent 18, build-helper-maven-plugin hacks around groovy no longer necessary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>14</version>
+        <version>18</version>
         <relativePath/>
     </parent>
 
@@ -84,11 +84,6 @@
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>build-helper-maven-plugin</artifactId>
                         <executions>
-                            <execution>
-                              <!-- To be removed when parent is released https://github.com/powsybl/powsybl-parent/pull/50 -->
-                              <id>attach-artifact</id>
-                              <phase>none</phase>
-                            </execution>
                             <execution>
                                 <id>add-cpp-source</id>
                                 <phase>generate-sources</phase>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
NO


**What kind of change does this PR introduce?**
code cleanup


**What is the current behavior?**
need a hack to disable groovydoc attach


**What is the new behavior (if this is a feature change)?**
no more hack

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section