### PR TITLE
Fix crash with some compiler in case of KLU singular error

### DIFF
--- a/src/main/cpp/lu.cpp
+++ b/src/main/cpp/lu.cpp
@@ -192,6 +192,7 @@ JNIEXPORT jdouble JNICALL Java_com_powsybl_math_matrix_SparseLUDecomposition_upd
     } catch (...) {
         powsybl::jni::throwMatrixException(env, "Unknown exception");
     }
+    return 0;
 }
 
 /*


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
With some compiler in release mode, we crash because a method supposed to return a double value does not return anything.
Using previous build environnement we never add any crash but using the manylinux2014 and its default gcc version we get a sigabort.

**What is the new behavior (if this is a feature change)?**
We return whatever value (0) because on Java side an exception in thrown and the value will never be used.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
